### PR TITLE
refactor: consolidate symbol panel visibility state

### DIFF
--- a/src/app/editing-toolbar/editing-toolbar.component.ts
+++ b/src/app/editing-toolbar/editing-toolbar.component.ts
@@ -225,7 +225,7 @@ constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer, private open
     }
 
     if(canceled){
-      this.openLayersService.raiseSymbolPanelClosed(true)
+      this.openLayersService.updateShowSymbolPanel({visible: false})
     }
    }
 

--- a/src/app/layer-panel/layer-panel.component.ts
+++ b/src/app/layer-panel/layer-panel.component.ts
@@ -133,7 +133,7 @@ constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer, private open
           // stop editing
           layer.onEdit = false;
           this.openLayersService.updateShowEditToolbar(false);
-          this.openLayersService.raiseSymbolPanelClosed(true)
+          this.openLayersService.updateShowSymbolPanel({visible: false})
           this.editLayerClick.emit(null);
           return;
         }
@@ -193,7 +193,7 @@ constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer, private open
       layer.onEdit = false;
       this.editLayerClick.emit(null);
       this.openLayersService.updateShowEditToolbar(false);
-      this.openLayersService.raiseSymbolPanelClosed(true)
+      this.openLayersService.updateShowSymbolPanel({visible: false})
       layer.onIdentify = true;
       this.identifyLayerClick.emit({layer, groupName});
       return;
@@ -205,7 +205,7 @@ constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer, private open
     this.updateEditActionInLayers(this.layerActive);
     // workaround..
     this.openLayersService.updateShowEditToolbar(false);
-    this.openLayersService.raiseSymbolPanelClosed(true)
+    this.openLayersService.updateShowSymbolPanel({visible: false})
     this.editLayerClick.emit(null);
     // set the selected layer as active
     this.layerActive = layer.layerName;

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -204,7 +204,7 @@ export class MapComponent implements OnInit, AfterViewInit, OnDestroy {
   subsToSaveAllLayers: Subscription;
   subsToStreetSelected: Subscription;
   subsToCustomDialogClosed: Subscription;
-  subsToSymbolPanelClosed: Subscription;
+  subsToShowSymbolPanel: Subscription;
   subsToEditAborted: Subscription;
   subsToGeolocation: Subscription;
 
@@ -318,16 +318,16 @@ export class MapComponent implements OnInit, AfterViewInit, OnDestroy {
         console.error('Error while adding street feature to map', error);
       }
     );
-    this.subsToSymbolPanelClosed=  this.openLayersService.symbolPanelClosed$.subscribe(
-      (isCanceled) => {
-        console.log(isCanceled)
-          this.symbolPanelOpen = !isCanceled;
-        },
-      (error) => {
-        console.error('Error while adding street feature to map', error);
-      }
-    );
-
+this.subsToShowSymbolPanel =
+  this.openLayersService.showSymbolPanel$.subscribe(
+    (showPanel) => {
+      console.log(showPanel);
+      this.symbolPanelOpen = showPanel;
+    },
+    (error) => {
+      console.error('Error while updating symbol panel state', error);
+    }
+  );
     this.subsToCustomDialogClosed = this.customDialogInitializer.dialogClosed$.subscribe(
       (data) =>{
         console.log("received dialog closed event")

--- a/src/app/open-layers.service.ts
+++ b/src/app/open-layers.service.ts
@@ -43,8 +43,6 @@ export class OpenLayersService {
   showStreetSearch$ = this.showStreetSearchSource.asObservable();
   private streetSelectedSource = new Subject<Feature>();
   streetSelected$ = this.streetSelectedSource.asObservable();
-  private symbolPanelClosed = new Subject<boolean>();
-  symbolPanelClosed$ = this.symbolPanelClosed.asObservable();
   private zoomToLocation = new Subject<any>();
   zoomToLocation$ = this.zoomToLocation.asObservable();
   private streetSearchConfigured = new Subject<boolean>();
@@ -176,10 +174,6 @@ export class OpenLayersService {
      * @param data: the result of the query returned by the API
      */
     this.findInstitutionsExposedSource.next(data);
-  }
-
-  raiseSymbolPanelClosed(isAborted: boolean){
-    this.symbolPanelClosed.next(isAborted)
   }
 
   updateStreetSearchConfigured(isConfigured: boolean){

--- a/src/app/symbol-list/symbol-list.component.ts
+++ b/src/app/symbol-list/symbol-list.component.ts
@@ -68,7 +68,7 @@ export class SymbolListComponent implements OnInit, AfterViewInit {
       this.symbolActiveKey = null;
       // updates the selected symbol
       this.openLayersService.updateCurrentSymbol(null);
-      this.openLayersService.raiseSymbolPanelClosed(isCanceled)
+      this.openLayersService.updateShowSymbolPanel({visible: false})
     }
     this.displaySymbolList$ = observableOf(visibility.visible);
   }


### PR DESCRIPTION
What changed

This PR removes the unused/redundant symbolPanelClosed$ observable from OpenLayersService and uses showSymbolPanel$ as the single source of truth for symbol panel visibility.

Replaced all usages of:

raiseSymbolPanelClosed(...)

with:

updateShowSymbolPanel({ visible: false })

Updated:

editing-toolbar.component.ts
layer-panel.component.ts
symbol-list.component.ts

Also renamed:

subsToSymbolPanelClosed

to:

subsToShowSymbolPanel

in map.component.ts since it now subscribes directly to the visibility state.

Why

symbolPanelClosed$ and showSymbolPanel$ were representing overlapping state. Since showSymbolPanel$ already indicates whether the panel is open or closed, the extra observable wasn’t needed.

This simplifies the visibility handling and avoids maintaining duplicate state.